### PR TITLE
Add Persistent storage integration for scoreboard with Firebase

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -12,6 +13,7 @@ android {
         targetSdk 32
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -40,11 +42,15 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation platform('com.google.firebase:firebase-bom:29.0.3')
+    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-database-ktx'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,40 @@
+{
+  "project_info": {
+    "project_number": "540215599572",
+    "firebase_url": "https://mc---sudoku-project-default-rtdb.europe-west1.firebasedatabase.app",
+    "project_id": "mc---sudoku-project",
+    "storage_bucket": "mc---sudoku-project.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:540215599572:android:d9597d2c3fa3d3f5d57641",
+        "android_client_info": {
+          "package_name": "com.example.sudoku"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "540215599572-7pej1f12ttrvlj8b0adsmeifcj2hms7q.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDmbeBxTdIrfG_AFixLm4mUDV2ttBRq6E4"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "540215599572-7pej1f12ttrvlj8b0adsmeifcj2hms7q.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/example/sudoku/Scoreboard.kt
+++ b/app/src/main/java/com/example/sudoku/Scoreboard.kt
@@ -1,10 +1,13 @@
 package com.example.sudoku
 
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
+import android.widget.Button
+import android.widget.EditText
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -12,42 +15,103 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sudoku.databinding.FragmentScoreboardBinding
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.GenericTypeIndicator
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
 
 class Scoreboard : Fragment() {
+    private val DB_URL: String = "https://mc---sudoku-project-default-rtdb.europe-west1.firebasedatabase.app"
+    private val EVENT_TAG: String = "Scoreboard event"
+
+    private lateinit var database: DatabaseReference
+    private lateinit var scoreboardViewAdapter: ScoreboardViewAdapter
+    private val highScoresDataset: MutableList<ScoreboardEntryModel> = ArrayList(getHeaderHighScoreItems())
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        database = Firebase.database(DB_URL).reference
+
         // Inflate the layout for this fragment
-        val binding = DataBindingUtil.inflate<FragmentScoreboardBinding>(inflater, R.layout.fragment_scoreboard, container, false)
+        val binding = DataBindingUtil.inflate<FragmentScoreboardBinding>(
+            inflater,
+            R.layout.fragment_scoreboard,
+            container,
+            false
+        )
 
         binding.buttonBackScoreboard.setOnClickListener {
             findNavController().navigate(R.id.action_scoreboard_to_mainMenu)
         }
         setupRecyclerView(binding)
+        setupAddScoreButton(binding.root)
 
         return binding.root
     }
 
-    private fun setupRecyclerView(binding: FragmentScoreboardBinding) {
-        val recyclerView = binding.root.findViewById<RecyclerView>(R.id.recycler_view_scoreboard)
-        val layoutManager = binding.root.findViewById<ConstraintLayout>(R.id.layout_manager_recycler_scoreboard)
-        recyclerView.layoutManager = LinearLayoutManager(layoutManager.context)
-        val adapter = ScoreboardViewAdapter(getHighScoresDataset())
-        recyclerView.adapter = adapter
+    private fun setupAddScoreButton(view: View) {
+        val addScoreButton = view.findViewById<Button>(R.id.add_highscore_button)
+        addScoreButton.setOnClickListener{
+            addNewHighScore(view)
+        }
     }
 
-    // TODO (future PR): replace mock data with an actual call to the DB collection.
-    private fun getHighScoresDataset(): List<ScoreboardEntryModel> {
-        return listOf(
-            ScoreboardEntryModel("#", "Player name", "Score"),
-            ScoreboardEntryModel("1", "Awesome Awesome-o", "100"),
-            ScoreboardEntryModel("2", "Bro Broski", "85"),
-            ScoreboardEntryModel("3", "CC", "10"),
-            ScoreboardEntryModel("4", "Davie", "5"),
-            ScoreboardEntryModel("13", "Nobody Near Nowhere Nonending Name", "0"),
+    // Only for demo purposes.
+    private fun addNewHighScore(view: View) {
+        val nicknameEditText = view.findViewById<EditText>(R.id.highscore_nickname)
+        val score = highScoresDataset.last().score.toInt() + 1
 
+        val scoreEntry = ScoreboardEntryModel("", nicknameEditText.text.toString(), score.toString())
+        val scoresReference = database.child("scoreboard").child("scorepoints")
+        val entryKey = scoresReference.push().key
+        scoresReference.updateChildren(mapOf(
+            entryKey to scoreEntry
+        )).addOnSuccessListener {
+            Log.i(EVENT_TAG, "Added new score!")
+            // The real "Submit new score" button won't require a view-model update.
+            updateHighScoresDataset()
+        }
+    }
+
+    private fun setupRecyclerView(binding: FragmentScoreboardBinding) {
+        val recyclerView = binding.root.findViewById<RecyclerView>(R.id.recycler_view_scoreboard)
+        val layoutManager =
+            binding.root.findViewById<ConstraintLayout>(R.id.layout_manager_recycler_scoreboard)
+        recyclerView.layoutManager = LinearLayoutManager(layoutManager.context)
+        scoreboardViewAdapter = ScoreboardViewAdapter(highScoresDataset)
+        recyclerView.adapter = scoreboardViewAdapter
+        updateHighScoresDataset()
+    }
+
+    private fun updateHighScoresDataset() {
+        highScoresDataset.clear()
+        highScoresDataset.addAll(getHeaderHighScoreItems())
+        addTopScores()
+    }
+
+    private fun getHeaderHighScoreItems(): List<ScoreboardEntryModel> {
+        return listOf(
+            ScoreboardEntryModel("#", "Player name", "Score")
         )
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    private fun addTopScores() {
+        val topScoresQuery = database.child("scoreboard").child("scorepoints")
+            .orderByChild("score")
+            .limitToFirst(100)
+
+        topScoresQuery.get().addOnSuccessListener {
+            Log.i(EVENT_TAG, "Got value ${it.value}")
+            val genericTypeIndicator = object : GenericTypeIndicator<Map<String, ScoreboardEntryModel>>(){}
+            val entryByKey = it.getValue(genericTypeIndicator)!!
+            val sortedEntries = entryByKey.values.sortedWith(ScoreboardEntryModel.ScorePointsComparator)
+            highScoresDataset.addAll(sortedEntries)
+            scoreboardViewAdapter.notifyDataSetChanged()
+        }.addOnFailureListener {
+            Log.e(EVENT_TAG, "Error while fetching data", it)
+        }
     }
 }

--- a/app/src/main/java/com/example/sudoku/Scoreboard.kt
+++ b/app/src/main/java/com/example/sudoku/Scoreboard.kt
@@ -37,25 +37,8 @@ class Scoreboard : Fragment() {
             findNavController().navigate(R.id.action_scoreboard_to_mainMenu)
         }
         setupRecyclerView(binding)
-        setupAddScoreButton(binding.root)
 
         return binding.root
-    }
-
-    private fun setupAddScoreButton(view: View) {
-        val addScoreButton = view.findViewById<Button>(R.id.add_highscore_button)
-        addScoreButton.setOnClickListener{
-            addNewHighScore(view)
-        }
-    }
-
-    // Only for demo purposes.
-    private fun addNewHighScore(view: View) {
-        val nicknameEditText = view.findViewById<EditText>(R.id.highscore_nickname)
-        val score = highScoresDataset.last().score.toInt() + 1
-
-        val scoreEntry = ScoreboardEntryModel("", nicknameEditText.text.toString(), score.toString())
-        storageService.writeScoreEntry(scoreEntry)
     }
 
     private fun setupRecyclerView(binding: FragmentScoreboardBinding) {

--- a/app/src/main/java/com/example/sudoku/ScoreboardEntryModel.kt
+++ b/app/src/main/java/com/example/sudoku/ScoreboardEntryModel.kt
@@ -1,4 +1,15 @@
 package com.example.sudoku
 
-data class ScoreboardEntryModel(val rank: String, val playerName: String, val score: String) {
+import com.google.firebase.database.IgnoreExtraProperties
+
+@IgnoreExtraProperties
+data class ScoreboardEntryModel(val rank: String = "", val playerName: String = "", val score: String = "") {
+
+    object ScorePointsComparator: Comparator<ScoreboardEntryModel> {
+        override fun compare(p0: ScoreboardEntryModel?, p1: ScoreboardEntryModel?): Int {
+            val p0Score: Int = p0?.score?.toInt()?:0
+            val p1Score: Int = p1?.score?.toInt()?:0
+            return p1Score - p0Score
+        }
+    }
 }

--- a/app/src/main/java/com/example/sudoku/ScoreboardViewAdapter.kt
+++ b/app/src/main/java/com/example/sudoku/ScoreboardViewAdapter.kt
@@ -2,6 +2,8 @@ package com.example.sudoku
 
 import android.annotation.SuppressLint
 import android.graphics.Typeface.BOLD
+import android.graphics.Typeface.NORMAL
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -36,24 +38,24 @@ class ScoreboardViewAdapter(private val dataSet: List<ScoreboardEntryModel>) :
 
     // Replace the contents of a view (invoked by the layout manager)
     override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
-        if (position == 0) {
-            setupHeaderRow(viewHolder)
-        }
+        setupRowStyle(viewHolder, position == 0)
         viewHolder.rankView.text = dataSet[position].rank.ifEmpty { position.toString() }
         viewHolder.playerNameView.text = dataSet[position].playerName
         viewHolder.scoreView.text = dataSet[position].score
     }
 
-    private fun setupHeaderRow(viewHolder: ViewHolder) {
-        applyHeaderStyle(viewHolder.rankView)
-        applyHeaderStyle(viewHolder.playerNameView)
-        applyHeaderStyle(viewHolder.scoreView)
+    private fun setupRowStyle(viewHolder: ViewHolder, isHeader: Boolean) {
+        applyTextViewStyle(viewHolder.rankView, isHeader)
+        applyTextViewStyle(viewHolder.playerNameView, isHeader)
+        applyTextViewStyle(viewHolder.scoreView, isHeader)
     }
 
     @SuppressLint("ResourceAsColor")
-    private fun applyHeaderStyle(textView: TextView) {
-        textView.setTextColor(R.color.purple_500)
-        textView.setTypeface(null, BOLD)
+    private fun applyTextViewStyle(textView: TextView, isHeader: Boolean) {
+        val color = if (isHeader) R.color.purple_500 else R.color.black
+        textView.setTextColor(color)
+        val style = if (isHeader) BOLD else NORMAL
+        textView.setTypeface(null, style)
     }
 
     // Return the size of your dataset (invoked by the layout manager)

--- a/app/src/main/java/com/example/sudoku/ScoreboardViewAdapter.kt
+++ b/app/src/main/java/com/example/sudoku/ScoreboardViewAdapter.kt
@@ -39,7 +39,7 @@ class ScoreboardViewAdapter(private val dataSet: List<ScoreboardEntryModel>) :
         if (position == 0) {
             setupHeaderRow(viewHolder)
         }
-        viewHolder.rankView.text = dataSet[position].rank
+        viewHolder.rankView.text = dataSet[position].rank.ifEmpty { position.toString() }
         viewHolder.playerNameView.text = dataSet[position].playerName
         viewHolder.scoreView.text = dataSet[position].score
     }

--- a/app/src/main/java/com/example/sudoku/Win.kt
+++ b/app/src/main/java/com/example/sudoku/Win.kt
@@ -6,14 +6,18 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
 import androidx.databinding.DataBindingUtil
 import androidx.navigation.fragment.findNavController
 import com.example.sudoku.databinding.FragmentWinBinding
+import com.example.sudoku.service.StorageService
 
 private const val ARG_SCORE = "score"
 
 class Win : Fragment() {
     private var score: String? = null
+    private val storageService: StorageService = StorageService()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,9 +36,25 @@ class Win : Fragment() {
         binding.buttonBackWin.setOnClickListener {
             findNavController().navigate(R.id.action_win_to_mainMenu)
         }
+        setupAddScoreButton(binding.root)
 
         binding.winScoreText.text = "Score $score"
 
         return binding.root
+    }
+
+    private fun setupAddScoreButton(view: View) {
+        val addScoreButton = view.findViewById<Button>(R.id.add_highscore_button)
+        addScoreButton.setOnClickListener{
+            addNewHighScore(view)
+            findNavController().navigate(R.id.action_win_to_scoreboard)
+        }
+    }
+
+    private fun addNewHighScore(view: View) {
+        val nicknameEditText = view.findViewById<EditText>(R.id.highscore_nickname)
+        val score = this.score?:"0"
+        val scoreEntry = ScoreboardEntryModel("", nicknameEditText.text.toString(), score)
+        storageService.writeScoreEntry(scoreEntry)
     }
 }

--- a/app/src/main/java/com/example/sudoku/service/StorageService.kt
+++ b/app/src/main/java/com/example/sudoku/service/StorageService.kt
@@ -1,0 +1,54 @@
+package com.example.sudoku.service
+
+import android.util.Log
+import com.example.sudoku.ScoreboardEntryModel
+import com.google.android.gms.tasks.Task
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.GenericTypeIndicator
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
+
+private const val EVENT_TAG: String = "Storage system event"
+private const val DB_URL: String =
+    "https://mc---sudoku-project-default-rtdb.europe-west1.firebasedatabase.app"
+
+class StorageService {
+    private var database: DatabaseReference = Firebase.database(DB_URL).reference
+
+    fun writeScoreEntry(scoreEntry: ScoreboardEntryModel): Task<Void> {
+        val scoresReference = database.child("scoreboard").child("scorepoints")
+        val entryKey = scoresReference.push().key
+        val jsonDoc = mapOf(entryKey to scoreEntry)
+
+        return scoresReference.updateChildren(jsonDoc)
+            .addOnSuccessListener {
+                Log.i(EVENT_TAG, "Added new score!")
+            }.addOnFailureListener {
+                Log.e(EVENT_TAG, "Error while writing data", it)
+            }
+    }
+
+    fun readScoreEntries(successCallback: (List<ScoreboardEntryModel>) -> Unit) {
+        val topScoresQuery = database.child("scoreboard").child("scorepoints")
+            .orderByChild("score")
+            .limitToFirst(100)
+
+        topScoresQuery.get()
+            .addOnSuccessListener {
+                Log.i(EVENT_TAG, "Got value ${it.value}")
+                val sortedEntries = extractScoreEntries(it)
+                successCallback(sortedEntries)
+            }.addOnFailureListener {
+                Log.e(EVENT_TAG, "Error while fetching data", it)
+            }
+    }
+
+    private fun extractScoreEntries(dataSnapshot: DataSnapshot): List<ScoreboardEntryModel> {
+        val genericTypeIndicator =
+            object : GenericTypeIndicator<Map<String, ScoreboardEntryModel>>() {}
+        val entryByKey = dataSnapshot.getValue(genericTypeIndicator)!!
+        return entryByKey.values.sortedWith(ScoreboardEntryModel.ScorePointsComparator)
+    }
+
+}

--- a/app/src/main/res/layout/fragment_scoreboard.xml
+++ b/app/src/main/res/layout/fragment_scoreboard.xml
@@ -23,22 +23,6 @@
             android:textSize="60sp"
             android:textStyle="bold" />
 
-        <com.google.android.material.tabs.TabLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <com.google.android.material.tabs.TabItem
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/scoreboard_highest_points" />
-
-            <com.google.android.material.tabs.TabItem
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/scoreboard_best_times" />
-
-        </com.google.android.material.tabs.TabLayout>
-
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_manager_recycler_scoreboard"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_scoreboard.xml
+++ b/app/src/main/res/layout/fragment_scoreboard.xml
@@ -39,19 +39,6 @@
 
         </com.google.android.material.tabs.TabLayout>
 
-        <EditText
-            android:id="@+id/highscore_nickname"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:hint="@string/what_is_your_nickname"
-            android:inputType="textPersonName" />
-
-        <Button
-            android:id="@+id/add_highscore_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/add_highscore_button" />
-
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_manager_recycler_scoreboard"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_scoreboard.xml
+++ b/app/src/main/res/layout/fragment_scoreboard.xml
@@ -39,6 +39,19 @@
 
         </com.google.android.material.tabs.TabLayout>
 
+        <EditText
+            android:id="@+id/highscore_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:hint="@string/what_is_your_nickname"
+            android:inputType="textPersonName" />
+
+        <Button
+            android:id="@+id/add_highscore_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/add_highscore_button" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_manager_recycler_scoreboard"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_win.xml
+++ b/app/src/main/res/layout/fragment_win.xml
@@ -29,6 +29,19 @@
             android:textSize="34sp"
             android:textStyle="bold" />
 
+        <EditText
+            android:id="@+id/highscore_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:hint="@string/what_is_your_nickname"
+            android:inputType="textPersonName" />
+
+        <Button
+            android:id="@+id/add_highscore_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/add_highscore_button" />
+
         <Button
             android:id="@+id/button_back_win"
             android:layout_width="match_parent"

--- a/app/src/main/res/navigation/my_nav.xml
+++ b/app/src/main/res/navigation/my_nav.xml
@@ -65,6 +65,9 @@
             android:name="score"
             app:argType="string"
             android:defaultValue="0" />
+        <action
+            android:id="@+id/action_win_to_scoreboard"
+            app:destination="@id/scoreboard" />
     </fragment>
     <fragment
         android:id="@+id/lose"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,6 @@
     <string name="scoreboard_highest_points">Highest Points</string>
     <string name="scoreboard_best_times">Best Times</string>
     <string name="default_scoreboard_text">No player yet</string>
+    <string name="what_is_your_nickname">What is your Nickname?</string>
+    <string name="add_highscore_button">Add highscore</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath 'com.google.gms:google-services:4.3.10'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This adds support for Firebase realtime DB - documents are saved in JSON format in a Firebase DB cluster (west-europe).

CC: @raduciobanu, @radumarin88, for tracking the project progress

Sample app view:
<img width="400" alt="Screenshot 2022-01-14 at 13 39 31" src="https://user-images.githubusercontent.com/26903571/149510407-ca4d9f37-df0c-4b57-95f7-4e4b8d9a315e.png">

Sample FirebaseDB view:
<img width="942" alt="Screenshot 2022-01-14 at 13 40 40" src="https://user-images.githubusercontent.com/26903571/149510444-477a3e44-1af3-43ac-ab9c-e0f0a9664e3e.png">

